### PR TITLE
Replace cargo-tarpaulin with cargo-llvm-cov

### DIFF
--- a/pkgs/rust-dev-path.nix
+++ b/pkgs/rust-dev-path.nix
@@ -2,7 +2,7 @@
   symlinkJoin,
   # keep-sorted start
   cargo,
-  cargo-tarpaulin,
+  cargo-llvm-cov,
   clippy,
   rust-analyzer,
   rustc,
@@ -14,7 +14,7 @@ symlinkJoin {
   paths = [
     # keep-sorted start
     cargo
-    cargo-tarpaulin
+    cargo-llvm-cov
     clippy
     rust-analyzer
     rustc


### PR DESCRIPTION
## Summary
- use cargo-llvm-cov instead of cargo-tarpaulin in the `rust-dev-path` package

## Testing
- `nix fmt`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68a3811dc8dc832691731bf93d5916b8