### PR TITLE
Remove cargo-tarpaulin from rust-dev-path

### DIFF
--- a/pkgs/rust-dev-path.nix
+++ b/pkgs/rust-dev-path.nix
@@ -2,7 +2,6 @@
   symlinkJoin,
   # keep-sorted start
   cargo,
-  cargo-tarpaulin,
   clippy,
   rust-analyzer,
   rustc,
@@ -14,7 +13,6 @@ symlinkJoin {
   paths = [
     # keep-sorted start
     cargo
-    cargo-tarpaulin
     clippy
     rust-analyzer
     rustc


### PR DESCRIPTION
## Summary
- drop cargo-tarpaulin from `rust-dev-path`

## Testing
- `nix fmt pkgs/rust-dev-path.nix`
- `nix --log-format raw flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68a3909a1364832686cfe66d9eeb9dfc