### PR TITLE
Fix jj rebase-all alias for upcoming revset changes

### DIFF
--- a/pkgs/jujutsu-config.nix
+++ b/pkgs/jujutsu-config.nix
@@ -73,7 +73,7 @@ let
       rebase-all = [
         "rebase"
         "--branch"
-        "all:bookmarks()"
+        "bookmarks()"
         "--destination"
         "trunk()"
       ];


### PR DESCRIPTION
## Summary
- drop deprecated `all:` prefix from `jj rebase-all` alias

## Testing
- `nix flake archive`
- `nix flake archive ./internal/`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68a9f71eceb08326bbe7f3c524795b1f