### PR TITLE
Add jj-new-main wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,7 @@ These flags will give you the most verbose output for debugging. When running in
 ## Formatting
 
 `nix flake check` will also check if source files are formatted correctly. If there is a formatting issue, run `nix fmt` to fix it.
+
+## Packages
+
+Packages defined under `pkgs/` are automatically exposed in the flake's package set.

--- a/pkgs/jujutsu-new-main.bash
+++ b/pkgs/jujutsu-new-main.bash
@@ -1,0 +1,4 @@
+set -o xtrace
+
+jj git fetch --remote origin
+jj new main@origin

--- a/pkgs/jujutsu-new-main.nix
+++ b/pkgs/jujutsu-new-main.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  writeShellApplication,
+  jujutsu,
+  nixbits,
+}:
+writeShellApplication {
+  name = "jj-new-main";
+  runtimeInputs = [
+    jujutsu
+  ];
+  inheritPath = false;
+  runtimeEnv = {
+    JJ_CONFIG = nixbits.jujutsu-config;
+  };
+  text = builtins.readFile ./jujutsu-new-main.bash;
+  meta = {
+    description = "Fetch origin then create new change from main@origin";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/jujutsu.nix
+++ b/pkgs/jujutsu.nix
@@ -17,6 +17,7 @@ let
       nixbits.jujutsu-bookmark-clean
       nixbits.jujutsu-clone
       nixbits.jujutsu-git-set-upstream
+      nixbits.jujutsu-new-main
       nixbits.jujutsu-pull
       watchman
     ];


### PR DESCRIPTION
## Summary
- add `jj-new-main` to fetch `origin` and start a change from `main@origin`
- document auto-exposed package pattern for future contributors

## Testing
- `nix flake archive`
- `nix flake archive ./internal/`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`
- `nix fmt`


------
https://chatgpt.com/codex/tasks/task_e_68aaa06842b0832691923bf365a48ccf