### PR TITLE
fix: grant label edit permission

### DIFF
--- a/.github/workflows/flake-lockfile.yml
+++ b/.github/workflows/flake-lockfile.yml
@@ -5,6 +5,7 @@ on: pull_request
 permissions:
   id-token: "write"
   contents: "read"
+  issues: "write"
 
 jobs:
   lockfile-drv-changed:


### PR DESCRIPTION
## Summary
- allow flake-lockfile workflow to edit PR labels using issues write permission

## Testing
- `nix flake archive`
- `nix flake archive ./internal/`
- `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going`


------
https://chatgpt.com/codex/tasks/task_e_68abe9086dd083269635321f1446ce75