### PR TITLE
Silence gh pr edit output

### DIFF
--- a/pkgs/gh-actions-compare-pr-flake-lockfile.bash
+++ b/pkgs/gh-actions-compare-pr-flake-lockfile.bash
@@ -34,14 +34,14 @@ fi
 
 if jd -color "$a_out" "$b_out"; then
   echo "status=no-change" >>"$GITHUB_OUTPUT"
-  if ! gh pr edit "$PR_URL" --add-label "noop"; then
+  if ! gh pr edit "$PR_URL" --add-label "noop" >/dev/null; then
     echo "::warning::Error adding label" >&2
   fi
   echo "::notice::No changes detected" >&2
   exit 1
 else
   echo "status=change" >>"$GITHUB_OUTPUT"
-  if ! gh pr edit "$PR_URL" --remove-label "noop"; then
+  if ! gh pr edit "$PR_URL" --remove-label "noop" >/dev/null; then
     echo "::warning::Error removing label" >&2
   fi
   exit 0


### PR DESCRIPTION
## Summary
- suppress gh pr edit success output in gh-actions-compare-pr-flake-lockfile to avoid printing the PR URL

## Testing
- nix flake check --accept-flake-config

------
https://chatgpt.com/codex/tasks/task_e_68d19d051848832692bc3d9f3757f16e