### PR TITLE
Use ubuntu-slim runner for select workflows

### DIFF
--- a/.github/workflows/flake-lockfile.yml
+++ b/.github/workflows/flake-lockfile.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   lockfile-drv-changed:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
 
     steps:
       - name: Check changed files

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   merge:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     if: github.actor == 'dependabot[bot]' && github.repository == 'josh/nixbits'
 
     steps:


### PR DESCRIPTION
## Summary
- switch the merge automation workflow to run on the ubuntu-slim container runner
- update the flake lockfile comparison workflow to use the ubuntu-slim runner

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692371d636748326abb165aabf507648)