### PR TITLE
Use determinate-nix-action v3.13.2 in workflows

### DIFF
--- a/.github/workflows/flake-lockfile.yml
+++ b/.github/workflows/flake-lockfile.yml
@@ -24,7 +24,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
         if: steps.changed.outputs.only_lock_changed == 'true'
         with:
           extra-conf: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
         with:
           extra-conf: |
             accept-flake-config = true


### PR DESCRIPTION
## Summary
- replace nix-installer-action references with determinate-nix-action v3.13.2 in CI workflows

## Testing
- not run (CI workflow changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c95d1433483269f437aaed158d304)