### PR TITLE
Add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
## Summary
- add a cooldown interval to Dependabot updates for GitHub Actions

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e681aee2c83268d6755239c3cc720)