### PR TITLE
Update jj config to new auto-track-bookmarks setting

### DIFF
--- a/pkgs/jujutsu-config.nix
+++ b/pkgs/jujutsu-config.nix
@@ -22,8 +22,11 @@ let
 
     git = {
       executable-path = lib.getExe nixbits.git;
-      push-new-bookmarks = true;
       private-commits = "description(glob:'wip:*')";
+    };
+
+    remotes.origin = {
+      auto-track-bookmarks = "glob:*";
     };
 
     # No longer supported on darwin


### PR DESCRIPTION
## Summary
- replace deprecated git.push-new-bookmarks config with remotes.origin.auto-track-bookmarks

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934e3e4d75c8326ab262ebf9e509e3b)