### PR TITLE
Pin actions to full-length commit sha

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
 
       - name: Enable auto-merge
         if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'


### PR DESCRIPTION
## Summary
- pin the Dependabot fetch metadata action in merge workflow to its full commit SHA

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bd672fdc8326bef11c472d7a0448)