### PR TITLE
Remove jj 'wip:*' private-commits rule

### DIFF
--- a/pkgs/jujutsu-config.nix
+++ b/pkgs/jujutsu-config.nix
@@ -22,7 +22,6 @@ let
 
     git = {
       executable-path = lib.getExe nixbits.git;
-      private-commits = "description(glob:'wip:*')";
     };
 
     remotes.origin = {


### PR DESCRIPTION
### Motivation
- The Jujutsu config marked commits whose description matched `wip:*` as private commits, which prevented pushing WIP changes.
- Allow WIP commits to be pushed by removing the `private-commits` restriction from the jj configuration.

### Description
- Deleted the `private-commits = "description(glob:'wip:*')";` line from `pkgs/jujutsu-config.nix`.
- The change updates the generated `jj-config.toml` so descriptions starting with `wip:` are no longer treated as private.

### Testing
- No automated tests were run for this change.
- To validate the repository after this change, run `nix flake check --accept-flake-config --show-trace --print-build-logs --keep-going` as documented in `AGENTS.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955731aa704832696e9041edba5a467)