### PR TITLE
pkgs: use fully qualified lib paths consistently

### DIFF
--- a/pkgs/age-decrypt.nix
+++ b/pkgs/age-decrypt.nix
@@ -39,7 +39,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   outputs = [
     "out"
   ]
-  ++ (lib.optional finalAttrs.preinstallCheck "hooks");
+  ++ (lib.lists.optional finalAttrs.preinstallCheck "hooks");
 
   buildCommand = ''
     if [ -n "$ageIdentity" ]; then

--- a/pkgs/age.nix
+++ b/pkgs/age.nix
@@ -28,9 +28,9 @@ let
   age-plugin-yubikey' = age-plugin-yubikey;
 
   features =
-    (lib.optional seSupport "se")
-    ++ (lib.optional tpmSupport "tpm")
-    ++ (lib.optional yubikeySupport "yubikey");
+    (lib.lists.optional seSupport "se")
+    ++ (lib.lists.optional tpmSupport "tpm")
+    ++ (lib.lists.optional yubikeySupport "yubikey");
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = if features == [ ] then "age" else "age-with-${builtins.concatStringsSep "-" features}";
@@ -47,9 +47,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   paths = [
     age
   ]
-  ++ (lib.optional seSupport age-plugin-se')
-  ++ (lib.optional tpmSupport age-plugin-tpm')
-  ++ (lib.optional yubikeySupport age-plugin-yubikey');
+  ++ (lib.lists.optional seSupport age-plugin-se')
+  ++ (lib.lists.optional tpmSupport age-plugin-tpm')
+  ++ (lib.lists.optional yubikeySupport age-plugin-yubikey');
 
   buildCommand = ''
     mkdir -p $out

--- a/pkgs/atticadm-make-token.nix
+++ b/pkgs/atticadm-make-token.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook preCheck
     $SHELL -n "$target"
-    ${lib.meta.getExe shellcheck-minimal} "$target"
+    ${lib.getExe shellcheck-minimal} "$target"
     runHook postCheck
   '';
 

--- a/pkgs/helix-env-theme.nix
+++ b/pkgs/helix-env-theme.nix
@@ -9,7 +9,7 @@ let
   mkHelixExe =
     theme:
     let
-      themeAttrs = lib.optionalAttrs (theme != null) { inherit theme; };
+      themeAttrs = lib.attrsets.optionalAttrs (theme != null) { inherit theme; };
       helixConfig' = helixConfig // themeAttrs;
     in
     lib.getExe (

--- a/pkgs/nix-store-gc.nix
+++ b/pkgs/nix-store-gc.nix
@@ -44,7 +44,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook preCheck
     $SHELL -n "$target"
-    ${lib.meta.getExe shellcheck-minimal} "$target"
+    ${lib.getExe shellcheck-minimal} "$target"
     runHook postCheck
   '';
 

--- a/pkgs/restic-wrapper.nix
+++ b/pkgs/restic-wrapper.nix
@@ -19,7 +19,7 @@
   nixbits,
 }:
 let
-  toExePath = path: if lib.attrsets.isDerivation path then lib.meta.getExe path else path;
+  toExePath = path: if lib.attrsets.isDerivation path then lib.getExe path else path;
 
   age' = if age == pkgs.age then nixbits.age else age;
   restic-age-key' = restic-age-key.override {

--- a/pkgs/sops.nix
+++ b/pkgs/sops.nix
@@ -29,9 +29,9 @@ let
   age-plugin-yubikey' = age-plugin-yubikey;
 
   features =
-    (lib.optional seSupport "se")
-    ++ (lib.optional tpmSupport "tpm")
-    ++ (lib.optional yubikeySupport "yubikey");
+    (lib.lists.optional seSupport "se")
+    ++ (lib.lists.optional tpmSupport "tpm")
+    ++ (lib.lists.optional yubikeySupport "yubikey");
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = if features == [ ] then "sops" else "sops-with-${builtins.concatStringsSep "-" features}";
@@ -49,9 +49,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sops
     age
   ]
-  ++ (lib.optional seSupport age-plugin-se')
-  ++ (lib.optional tpmSupport age-plugin-tpm')
-  ++ (lib.optional yubikeySupport age-plugin-yubikey');
+  ++ (lib.lists.optional seSupport age-plugin-se')
+  ++ (lib.lists.optional tpmSupport age-plugin-tpm')
+  ++ (lib.lists.optional yubikeySupport age-plugin-yubikey');
 
   buildCommand = ''
     mkdir -p $out

--- a/pkgs/trakt-authorize-token.nix
+++ b/pkgs/trakt-authorize-token.nix
@@ -11,7 +11,7 @@
 writeShellApplication {
   name = "trakt-authorize-token";
   runtimeEnv = {
-    PATH = lib.makeBinPath [
+    PATH = lib.strings.makeBinPath [
       curl
       gnugrep
       gnused

--- a/pkgs/trakt-id-from-url.nix
+++ b/pkgs/trakt-id-from-url.nix
@@ -7,7 +7,7 @@
 writeShellApplication {
   name = "trakt-id-from-url";
   runtimeEnv = {
-    PATH = lib.makeBinPath [
+    PATH = lib.strings.makeBinPath [
       curl
       jq
     ];


### PR DESCRIPTION
Most of the repo spells out the lib namespace (lib.lists.optional, lib.strings.makeBinPath); convert the remaining top-level alias uses to match. lib.getExe stays as the repo-wide majority spelling, so the three lib.meta.getExe call sites move to it.