### PR TITLE
pkgs: enable __structuredAttrs on remaining derivations

### DIFF
--- a/pkgs/claude-skills.nix
+++ b/pkgs/claude-skills.nix
@@ -2,6 +2,8 @@
 stdenvNoCC.mkDerivation {
   name = "claude-skills";
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     mkdir -p $out
     cp -R ${../.claude/skills/gh} $out/gh

--- a/pkgs/clean-completed-reminders.nix
+++ b/pkgs/clean-completed-reminders.nix
@@ -6,6 +6,8 @@
 swiftPackages.stdenv.mkDerivation {
   name = "clean-completed-reminders";
 
+  __structuredAttrs = true;
+
   dontUnpack = true;
 
   nativeBuildInputs = [

--- a/pkgs/direnv-xdg-config-home.nix
+++ b/pkgs/direnv-xdg-config-home.nix
@@ -15,6 +15,8 @@ in
 stdenvNoCC.mkDerivation {
   name = "direnv-xdg-config-home";
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     mkdir -p $out/direnv
     cp ${config} $out/direnv/direnv.toml

--- a/pkgs/ensure-newline.nix
+++ b/pkgs/ensure-newline.nix
@@ -6,6 +6,8 @@
 stdenv.mkDerivation (finalAttrs: {
   name = "ensure-newline";
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     mkdir -p $out/bin
     $CC ${./ensure-newline.c} -o $out/bin/ensure-newline

--- a/pkgs/gtar.nix
+++ b/pkgs/gtar.nix
@@ -7,6 +7,8 @@ stdenvNoCC.mkDerivation {
   pname = "gtar";
   inherit (gnutar) version;
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     mkdir -p $out/bin
     ln -s ${lib.getExe gnutar} $out/bin/gtar

--- a/pkgs/launchd-exec.nix
+++ b/pkgs/launchd-exec.nix
@@ -6,6 +6,8 @@ stdenv.mkDerivation {
   pname = "launchd-exec";
   version = "0.1.0";
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     substitute ${./launchd-exec.c} launchd-exec.c \
       --replace-fail '@version@' "$version"

--- a/pkgs/mit-license.nix
+++ b/pkgs/mit-license.nix
@@ -18,12 +18,14 @@ in
 stdenvNoCC.mkDerivation (finalAttrs: {
   name = "mit-license";
 
+  __structuredAttrs = true;
+
   inherit script;
-  passAsFile = [ "script" ];
 
   buildCommand = ''
     mkdir -p $out/bin
-    install -m 755 $scriptPath $out/bin/mit-license
+    printf '%s' "$script" >$out/bin/mit-license
+    chmod 755 $out/bin/mit-license
     ln -s $out/bin/mit-license $out/bin/license
   '';
 

--- a/pkgs/tailscale-mas.nix
+++ b/pkgs/tailscale-mas.nix
@@ -28,6 +28,8 @@ in
 stdenvNoCC.mkDerivation {
   name = "tailscale-mas";
 
+  __structuredAttrs = true;
+
   buildCommand = ''
     mkdir -p $out/bin $out/share/mas $out/share/nix/hooks/pre-install.d $out/share/defaults.d
     install -m 755 ${wrapper} $out/bin/tailscale


### PR DESCRIPTION
Upstream requires __structuredAttrs on new packages and the rest of the repo already sets it; these eight were the stragglers.